### PR TITLE
resolving issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea
 /__pycache__/
 /.mypy_cache/
+/results/
 /pycoarsenet/__pycache__/
 /pycoarsenet/data/__pycache__/
 /pycoarsenet/training/__pycache__/


### PR DESCRIPTION
Added in epoch-wise losses normalised wrt length of training and
validation datasets. File handling now done via pathlib. `train` in
`train_model.py` now has more verbosity and logs results to a csv file
as well as printing to stdout.

Resolves: #6
Resolves: #18
