### PR TITLE
Plots verfied and corrected

### DIFF
--- a/src/train_model_CLR.py
+++ b/src/train_model_CLR.py
@@ -404,6 +404,7 @@ def main(args: argparse.Namespace) -> None:
 
         network.eval()
 
+        # below now accesses the right datasets
         model_predictions = network.forward(fl[val_loader.dataset.indices, :-1].float())
         labels = fl[val_loader.dataset.indices, -1]
 
@@ -460,10 +461,6 @@ def main(args: argparse.Namespace) -> None:
         dc_raw, df_raw = load_data(DATA_DIR, 't')
         fl = generate_features_labels(dc_raw, df_raw, 't')
         train_loader, val_loader = generate_dataloaders(fl)
-
-        # pass data into loaded model
-        # model_outputs = model.forward(feature_vector.float())
-        # model_loss = loss_fn(_model_outputs, label.unsqueeze(-1).float())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
An issue was present wherein the entire datasets where being plotted
rather than the validation or test portion. This was due to the way the
dataset was being accessed; the subset object after `random_split` has
access to the parent dataset and thus this was being plotted. This has
been corrected, and now the validation plots have the correct number of
data points, as do the eval plots.

Resolves: #43
